### PR TITLE
Makes Request::secure() take into account ssl preference

### DIFF
--- a/app/laravel/request.php
+++ b/app/laravel/request.php
@@ -112,7 +112,7 @@ class Request {
 	 */
 	public static function secure()
 	{
-		return isset($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) !== 'off';
+		return isset($_SERVER['HTTPS']) and strtolower($_SERVER['HTTPS']) !== 'off' and Config::$items['application']['ssl'];
 	}
 
 	/**


### PR DESCRIPTION
Hi. I ran into an issue with my server in which I had an https site configured but which was not the tinyissue site. Tinyissue kept trying to redirect to that other https site and failed. I thought that an easy fix would be to switch the ssl configuration option to false but that didn't seem to work. I looked in Request::secure() and saw that it looked at the server HTTPS configurations but did not recognize that they might be for another site not related to tinyissue so I added a check for the SSL configuration flag.
