### PR TITLE
Markdowned elements in issues and comments are not styled

### DIFF
--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -653,7 +653,28 @@ p{
     list-style-position: inside;
 }
 .issue code {
+    margin: 0 2px;
+    padding: 0px 5px;
+    border: 1px solid #EAEAEA;
+    background-color: #F8F8F8;
+    border-radius: 3px;
     font-family: monospace;
+}
+.issue pre {
+    background-color: #F8F8F8;
+    border: 1px solid #EAEAEA;
+    overflow: auto;
+    padding: 6px 10px;
+    border-radius: 3px;
+    margin: 15px 0;
+    font-family: monospace;
+    white-space: pre;
+}
+.issue pre code {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: transparent;
 }
 
 /* User list */


### PR DESCRIPTION
It's great to be able to use markdown in issues and comments, but the css reset left some elements unstyled.
I added some basic style to `ul`, `ol`, `pre` and `code` (for these last two, the style is from GitHub).
