### PR TITLE
Wrong comma in language array (master doesn't work)

### DIFF
--- a/app/application/language/en/tinyissue.php
+++ b/app/application/language/en/tinyissue.php
@@ -106,7 +106,7 @@ return array(
 	'you_put_no_comment' =>'You did not put in a comment!',
 	'user_deleted' => 'User Deleted',
 	'user_updated' => 'User Updated',
-	'user_added' => 'User Added'
-	'language' => 'Language',
+	'user_added' => 'User Added',
+	'language' => 'Language'
 
 );


### PR DESCRIPTION
current master doesn't work with this language file. syntax error, unexpected T_CONSTANT_ENCAPSED_STRING, expecting ')' in app/application/language/en/tinyissue.php on line 110
