### PR TITLE
Fixed configuration issue which produced fatal error after fresh install

### DIFF
--- a/app/paths.php
+++ b/app/paths.php
@@ -43,6 +43,11 @@ $paths['sys'] = 'laravel';
 $paths['bundle'] = 'bundles';
 
 // --------------------------------------------------------------
+// The path to the vendor directory.
+// --------------------------------------------------------------
+$paths['vendor'] = 'vendor';
+
+// --------------------------------------------------------------
 // The path to the storage directory.
 // --------------------------------------------------------------
 $paths['storage'] = 'storage';
@@ -87,11 +92,11 @@ foreach ($paths as $name => $path)
 
 /**
  * A global path helper function.
- * 
+ *
  * <code>
  *     $storage = path('storage');
  * </code>
- * 
+ *
  * @param  string  $path
  * @return string
  */
@@ -102,7 +107,7 @@ function path($path)
 
 /**
  * A global path setter function.
- * 
+ *
  * @param  string  $path
  * @param  string  $value
  * @return void


### PR DESCRIPTION
I cloned the application and followed the instructions to install. Everything went well until I tried to save a new user, then it errored looking for a vendor subscript in the paths array in app/paths.php file. I simply added a line defining the vendor subscript and set it to equal "vendor". A test of the application afterward demonstrated the fix worked.
