### PR TITLE
Autofocus on e-mail field on login page

### DIFF
--- a/app/application/views/layouts/login.php
+++ b/app/application/views/layouts/login.php
@@ -21,7 +21,7 @@
 					<tr><th colspan="2">Login to your account</th></tr>
 					<tr>
 						<th>Email</th>
-						<td><input type="text" name="email" /></td>
+						<td><input type="text" name="email" autofocus/></td>
 					</tr>
 					<tr>
 						<th>Password</th>


### PR DESCRIPTION
Very little improvement:

I added 'autofocus' flag in first text input on login page, so this field is focused automatically when page loads.

This way I do not have to click before typing the credentials, and people who set up their browser to save the credentials just have to press 'Enter' to log into tinyissue.