### PR TITLE
FIX: only create reopen link when user has sufficiant permissions

### DIFF
--- a/app/application/views/project/issue/index.php
+++ b/app/application/views/project/issue/index.php
@@ -112,6 +112,8 @@
 	</div>
 
 	<?php else: ?>
-	<?php echo HTML::link(Project\Issue::current()->to('status?status=1'), __('tinyissue.reopen_issue')); ?>
+		<?php if (Auth::user()->permission('issue-modify')): ?>
+			<?php echo HTML::link(Project\Issue::current()->to('status?status=1'), __('tinyissue.reopen_issue')); ?>
+		<?php endif; ?>
 	<?php endif; ?>
 </div>

--- a/app/assets/css/app.css
+++ b/app/assets/css/app.css
@@ -656,6 +656,11 @@ p{
 }
 
 /* style markdowned elements */
+.issue p,
+.issue ul,
+.issue ol {
+	margin-bottom: 10px;
+}
 .issue ul {
     list-style-type: disc;
     list-style-position: inside;
@@ -663,6 +668,15 @@ p{
 .issue ol {
     list-style-type: decimal;
     list-style-position: inside;
+}
+.issue ul ul,
+.issue ul ol,
+.issue ol ol,
+.issue ol ul {
+	margin: 0 0 0 12px;
+}
+.issue ul li {
+	margin-top: 2px;
 }
 .issue code {
     margin: 0 2px;
@@ -688,6 +702,15 @@ p{
     border: none;
     background-color: transparent;
 }
+.issue blockquote {
+	border-left: 2px solid #729fcf;
+	padding-left: 5px;
+}
+.issue blockquote blockquote { border-color: #ad7fa8; }
+.issue blockquote blockquote blockquote { border-color: #8ae234; }
+.issue blockquote blockquote blockquote blockquote { border-color: #fcaf3e; }
+.issue blockquote blockquote blockquote blockquote blockquote { border-color: #e9b96e; }
+
 .blue-box .activity .data .comment li {
     padding: 0;
     border-bottom: 0;


### PR DESCRIPTION
A simple user has the possibility to click the link to reopen a closed issue, which then leads to a 500 response due to missing permissions. This patch makes sure that the link is only being created when the user has sufficient rights.
