### PR TITLE
Blank page at installation

### DIFF
--- a/app/laravel/error.php
+++ b/app/laravel/error.php
@@ -84,7 +84,14 @@ class Error {
 		// of the exception details for the developer.
 		$exception = new \ErrorException($error, $code, 0, $file, $line);
 
-		if (in_array($code, Config::get('error.ignore')))
+		if( is_null( Config::get('error.ignore') ) )
+		{
+			$error_config = array();
+		}else{
+			$error_config = Config::get('error.ignore');
+		}
+
+		if (in_array($code, error_config))
 		{
 			return static::log($exception);
 		}


### PR DESCRIPTION
On my server I got a blank page at first call (install redirection).
Looking @apache errors I could read
"PHP Warning:  in_array() expects parameter 2 to be array, null given in [...]/app/laravel/error.php on line 87"
so I introduced a check : if the value return is null, change it for an empty array because '"in_array" only expect an array value, not a null value.
